### PR TITLE
Add BEQ catalogue support with load/clear services

### DIFF
--- a/monoprice_htp1/aiohtp1.py
+++ b/monoprice_htp1/aiohtp1.py
@@ -12,6 +12,17 @@ from .trigger_manager import TriggerManager
 import aiodns
 import aiohttp
 
+FILTER_TYPE_MAP = {"PeakingEQ": 0, "LowShelf": 1, "HighShelf": 2}
+BEQ_SLOT_START = 0
+BEQ_SLOT_END = 7
+
+
+def _num(v):
+    """Convert float to int when the value is a whole number (e.g. 10.0 -> 10)."""
+    if isinstance(v, float) and v == int(v):
+        return int(v)
+    return v
+
 
 class AioHtp1Exception(Exception):
     pass
@@ -241,7 +252,7 @@ class Htp1:
                     continue
 
                 op = piece.get("op")
-                if op not in ("add", "replace"):
+                if op not in ("add", "replace", "remove"):
                     continue
 
                 raw_path = piece.get("path")
@@ -260,6 +271,14 @@ class Htp1:
                     if isinstance(target, list):
                         node = int(node)
                     target = target[node]
+
+                if op == "remove":
+                    if isinstance(target, dict):
+                        target.pop(final, None)
+                    elif isinstance(target, list):
+                        del target[int(final)]
+                    await self._notify(raw_path, None)
+                    continue
 
                 value = piece.get("value")
 
@@ -1193,3 +1212,149 @@ class Htp1:
         if self._tx is None:
             raise AioHtp1Exception("no transaction in progress")
         self._tx["/channeltrim/channels/rhb"] = value
+
+    # ------------------------------------------------------------------
+    # BEQ (Bass EQ) support
+    # ------------------------------------------------------------------
+
+    @property
+    def beq_active(self) -> str | None:
+        """Title of the currently loaded BEQ filter, or None."""
+        if not self._state:
+            return None
+        return self._state.get("peq", {}).get("beqActive")
+
+    async def send_raw_ops(self, ops: list[dict]) -> bool:
+        """Send a list of raw JSON-Patch ops via changemso."""
+        if not ops:
+            return True
+        if not self._websocket:
+            raise AioHtp1Exception("Not connected")
+        payload = dumps(ops, separators=(",", ":"))
+        await self._websocket.send_str(f"changemso {payload}")
+        return True
+
+    def _get_sub_channels(self) -> list[str]:
+        """Return sub channel keys that are present in the speaker config."""
+        if not self._state:
+            return ["sub1"]
+        speakers = self._state.get("speakers", {}).get("groups", {})
+        subs = []
+        for key, val in speakers.items():
+            if key.startswith("sub") and isinstance(val, dict):
+                if val.get("present", False):
+                    subs.append(key)
+        return subs or ["sub1"]
+
+    def _find_empty_peq_slot(self, start_slot: int = BEQ_SLOT_START) -> int | None:
+        """Find the first empty PEQ slot in the BEQ range (8-15)."""
+        if not self._state:
+            return None
+        peq = self._state.get("peq", {})
+        slots = peq.get("slots", [])
+        sub_channels = self._get_sub_channels()
+        ch = sub_channels[0] if sub_channels else "sub1"
+        for i in range(start_slot, min(BEQ_SLOT_END + 1, len(slots))):
+            ch_data = slots[i].get("channels", {}).get(ch, {})
+            if ch_data.get("gaindB", 0) == 0 and not ch_data.get("beq"):
+                return i
+        return None
+
+    async def clear_beq(self) -> bool:
+        """Clear all BEQ-tagged filters from all PEQ slots on all sub channels."""
+        if not self._state:
+            return False
+        ops: list[dict] = []
+        peq = self._state.get("peq", {})
+        slots = peq.get("slots", [])
+        all_subs = ["sub1", "sub2", "sub3", "sub4", "sub5"]
+
+        for i in range(min(16, len(slots))):
+            channels = slots[i].get("channels", {})
+            for ch in all_subs:
+                ch_data = channels.get(ch, {})
+                if ch_data.get("beq"):
+                    ops.extend([
+                        {"op": "replace", "path": f"/peq/slots/{i}/channels/{ch}/Fc", "value": 100},
+                        {"op": "replace", "path": f"/peq/slots/{i}/channels/{ch}/gaindB", "value": 0},
+                        {"op": "replace", "path": f"/peq/slots/{i}/channels/{ch}/Q", "value": 1},
+                        {"op": "replace", "path": f"/peq/slots/{i}/channels/{ch}/FilterType", "value": 0},
+                        {"op": "remove", "path": f"/peq/slots/{i}/channels/{ch}/beq"},
+                    ])
+
+        if "beqActive" in peq:
+            ops.append({"op": "remove", "path": "/peq/beqActive"})
+
+        if ops:
+            return await self.send_raw_ops(ops)
+        return True
+
+    async def load_beq(self, title: str, filters: list[dict]) -> bool:
+        """Load BEQ filters into PEQ slots on all sub channels.
+
+        Builds a single changemso batch: clear existing BEQ-tagged slots,
+        remove beqActive, write new filter data, set beqActive, enable PEQ.
+        Matches the HTP-1 web UI (BassEq.vue) behavior.
+        """
+        if not self._state:
+            return False
+
+        sub_channels = self._get_sub_channels()
+        if not sub_channels:
+            return False
+
+        ops: list[dict] = []
+        all_subs = ["sub1", "sub2", "sub3", "sub4", "sub5"]
+
+        peq = self._state.get("peq", {})
+        slots = peq.get("slots", [])
+        for i in range(min(16, len(slots))):
+            channels = slots[i].get("channels", {})
+            for ch in all_subs:
+                ch_data = channels.get(ch, {})
+                if ch_data.get("beq"):
+                    ops.extend([
+                        {"op": "replace", "path": f"/peq/slots/{i}/channels/{ch}/Fc", "value": 100},
+                        {"op": "replace", "path": f"/peq/slots/{i}/channels/{ch}/gaindB", "value": 0},
+                        {"op": "replace", "path": f"/peq/slots/{i}/channels/{ch}/Q", "value": 1},
+                        {"op": "replace", "path": f"/peq/slots/{i}/channels/{ch}/FilterType", "value": 0},
+                        {"op": "remove", "path": f"/peq/slots/{i}/channels/{ch}/beq"},
+                    ])
+
+        if "beqActive" in peq:
+            ops.append({"op": "remove", "path": "/peq/beqActive"})
+
+        slot_idx = 0
+        for filt in filters:
+            while slot_idx < len(slots):
+                ch = sub_channels[0]
+                if slots[slot_idx].get("channels", {}).get(ch, {}).get("gaindB", 0) == 0:
+                    break
+                slot_idx += 1
+            else:
+                self.log.warning("No more empty PEQ slots for BEQ filter")
+                break
+
+            ft = FILTER_TYPE_MAP.get(filt.get("type", "PeakingEQ"), 0)
+            freq = _num(filt.get("freq", 100))
+            gain = _num(filt.get("gain", 0))
+            q = _num(filt.get("q", 1))
+
+            for ch in sub_channels:
+                ops.append({"op": "replace", "path": f"/peq/slots/{slot_idx}/channels/{ch}/Fc", "value": freq})
+                ops.append({"op": "replace", "path": f"/peq/slots/{slot_idx}/channels/{ch}/gaindB", "value": gain})
+                ops.append({"op": "replace", "path": f"/peq/slots/{slot_idx}/channels/{ch}/Q", "value": q})
+                if ft != 0:
+                    ops.append({"op": "replace", "path": f"/peq/slots/{slot_idx}/channels/{ch}/FilterType", "value": ft})
+                ops.append({"op": "add", "path": f"/peq/slots/{slot_idx}/channels/{ch}/beq", "value": True})
+            slot_idx += 1
+
+        ops.append({"op": "add", "path": "/peq/beqActive", "value": title})
+        ops.append({"op": "replace", "path": "/peq/peqsw", "value": True})
+
+        self.log.info("BEQ sending %d ops for %s", len(ops), title)
+        self.log.debug("BEQ ops: %s", dumps(ops, separators=(",", ":")))
+        success = await self.send_raw_ops(ops)
+        if success:
+            self.log.info("BEQ loaded: %s (%d filters)", title, len(filters))
+        return success

--- a/monoprice_htp1/beq.py
+++ b/monoprice_htp1/beq.py
@@ -1,0 +1,144 @@
+"""BEQ catalogue integration for Monoprice HTP-1.
+
+Fetches the BEQ (Bass EQ) catalogue and provides search functionality
+by movie title or TMDB ID. Mirrors the approach used in the Unfolded Circle
+integration but adapted for Home Assistant's service architecture.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import re
+from typing import Any
+
+import aiohttp
+
+_LOGGER = logging.getLogger(__name__)
+
+BEQ_DB_URL = "https://beqcatalogue.readthedocs.io/en/latest/database.json"
+CACHE_TTL = 3600  # 1 hour
+
+_beq_cache: list[dict] | None = None
+_beq_cache_time: float = 0
+
+
+async def async_fetch_catalogue(session: aiohttp.ClientSession) -> list[dict]:
+    """Fetch the BEQ catalogue from the remote database, with in-memory caching."""
+    global _beq_cache, _beq_cache_time  # noqa: PLW0603
+
+    now = asyncio.get_event_loop().time()
+    if _beq_cache is not None and (now - _beq_cache_time) < CACHE_TTL:
+        return _beq_cache
+
+    _LOGGER.info("Fetching BEQ catalogue from %s", BEQ_DB_URL)
+    try:
+        async with session.get(
+            BEQ_DB_URL, timeout=aiohttp.ClientTimeout(total=30)
+        ) as resp:
+            if resp.status != 200:
+                _LOGGER.error("BEQ catalogue fetch failed: HTTP %d", resp.status)
+                return _beq_cache or []
+            data = await resp.json(content_type=None)
+            if isinstance(data, list):
+                _beq_cache = data
+                _beq_cache_time = now
+                _LOGGER.info("BEQ catalogue loaded: %d entries", len(data))
+                return data
+    except Exception as err:
+        _LOGGER.error("BEQ catalogue fetch error: %s", err)
+    return _beq_cache or []
+
+
+def parse_tmdb_id(value: Any) -> int | None:
+    """Extract a numeric TMDB ID from an int, string, or themoviedb.org URL."""
+    if isinstance(value, int):
+        return value
+    if isinstance(value, str):
+        try:
+            return int(value)
+        except ValueError:
+            pass
+        match = re.search(r"/(?:movie|tv)/(\d+)", value)
+        if match:
+            return int(match.group(1))
+    return None
+
+
+def _extract_entry_tmdb_id(entry: dict) -> int | None:
+    """Extract the TMDB ID stored in a catalogue entry."""
+    raw = entry.get("theMovieDB") or entry.get("tmdbid") or entry.get("tmdb_id")
+    if raw is None:
+        return None
+    return parse_tmdb_id(raw)
+
+
+def _codec_matches(entry: dict, codec: str) -> bool:
+    """Check if an entry's audioTypes contain the requested codec."""
+    audio_types = entry.get("audioTypes", [])
+    codec_lower = codec.lower()
+    return any(codec_lower in at.lower() for at in audio_types)
+
+
+def search_by_title(
+    catalogue: list[dict],
+    title: str,
+    *,
+    year: int | None = None,
+    codec: str | None = None,
+) -> list[dict]:
+    """Search the BEQ catalogue by title (case-insensitive substring match)."""
+    query = title.lower().strip()
+    if not query:
+        return []
+
+    results = []
+    for entry in catalogue:
+        entry_title = entry.get("title", "").lower()
+        if query not in entry_title:
+            continue
+        if year is not None and entry.get("year") != year:
+            continue
+        if codec and not _codec_matches(entry, codec):
+            continue
+        results.append(entry)
+
+    return results
+
+
+def search_by_tmdb_id(
+    catalogue: list[dict],
+    tmdb_id: int,
+    *,
+    codec: str | None = None,
+) -> list[dict]:
+    """Search the BEQ catalogue by TMDB ID."""
+    results = []
+    for entry in catalogue:
+        entry_tmdb = _extract_entry_tmdb_id(entry)
+        if entry_tmdb != tmdb_id:
+            continue
+        if codec and not _codec_matches(entry, codec):
+            continue
+        results.append(entry)
+    return results
+
+
+def best_match(results: list[dict]) -> dict | None:
+    """Pick the best match from a list of search results.
+
+    Prefers entries with more filters (usually higher-quality profiles).
+    """
+    if not results:
+        return None
+    return max(results, key=lambda e: len(e.get("filters", [])))
+
+
+def prepare_filters(entry: dict) -> list[dict]:
+    """Extract filters from a catalogue entry, stripping biquad data."""
+    import copy
+
+    filters = copy.deepcopy(entry.get("filters", []))
+    for f in filters:
+        f.pop("biquads", None)
+    return filters

--- a/monoprice_htp1/manifest.json
+++ b/monoprice_htp1/manifest.json
@@ -7,5 +7,5 @@
   "integration_type": "device",
   "iot_class": "local_push",
   "loggers": ["aiohtp1", "monoprice_htp1"],
-  "version": "1.1.1"
+  "version": "1.2.0"
 }

--- a/monoprice_htp1/media_player.py
+++ b/monoprice_htp1/media_player.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import voluptuous as vol
+
 from homeassistant.components.media_player import (
     MediaPlayerEntity,
     MediaPlayerEntityFeature,
@@ -9,10 +11,14 @@ from homeassistant.components.media_player import (
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers import config_validation as cv, entity_platform
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 
+from . import beq
 from .aiohtp1 import Htp1
 from .const import DOMAIN, LOGGER, ui_lock_signal
 from .helpers import schedule_entity_update_threadsafe
@@ -31,6 +37,17 @@ UPMIX_RAW_TO_UI = {
 UPMIX_UI_TO_RAW = {v: k for k, v in UPMIX_RAW_TO_UI.items()}
 
 
+SERVICE_LOAD_BEQ = "load_beq_filter"
+SERVICE_CLEAR_BEQ = "clear_beq_filter"
+
+LOAD_BEQ_SCHEMA = {
+    vol.Optional("title"): cv.string,
+    vol.Optional("tmdb_id"): cv.string,
+    vol.Optional("year"): vol.Coerce(int),
+    vol.Optional("codec"): cv.string,
+}
+
+
 async def async_setup_entry(
     hass: HomeAssistant,
     entry: ConfigEntry,
@@ -39,6 +56,18 @@ async def async_setup_entry(
     """Set up the Monoprice HTP-1 config entry."""
     htp1: Htp1 = hass.data[DOMAIN][entry.entry_id]
     async_add_entities((Htp1MediaPlayer(htp1=htp1, entry_id=entry.entry_id),), True)
+
+    platform = entity_platform.async_get_current_platform()
+    platform.async_register_entity_service(
+        SERVICE_LOAD_BEQ,
+        LOAD_BEQ_SCHEMA,
+        "async_load_beq_filter",
+    )
+    platform.async_register_entity_service(
+        SERVICE_CLEAR_BEQ,
+        {},
+        "async_clear_beq_filter",
+    )
 
 
 class Htp1MediaPlayer(MediaPlayerEntity):
@@ -343,3 +372,77 @@ class Htp1MediaPlayer(MediaPlayerEntity):
         except Exception:
             LOGGER.debug("Failed to read source_list", exc_info=True)
             return []
+
+    # BEQ Services
+
+    async def async_load_beq_filter(
+        self,
+        title: str | None = None,
+        tmdb_id: str | None = None,
+        year: int | None = None,
+        codec: str | None = None,
+    ) -> None:
+        """Search the BEQ catalogue and load a bass correction filter."""
+        if not title and not tmdb_id:
+            raise HomeAssistantError(
+                "Either 'title' or 'tmdb_id' must be provided"
+            )
+
+        if not self.available:
+            raise HomeAssistantError("HTP-1 is not connected")
+
+        session = async_get_clientsession(self.hass)
+        catalogue = await beq.async_fetch_catalogue(session)
+
+        if not catalogue:
+            raise HomeAssistantError("Failed to fetch BEQ catalogue")
+
+        if tmdb_id:
+            tmdb_int = beq.parse_tmdb_id(tmdb_id)
+            if tmdb_int is None:
+                raise HomeAssistantError(f"Invalid TMDB ID: {tmdb_id}")
+            results = beq.search_by_tmdb_id(catalogue, tmdb_int, codec=codec)
+        else:
+            results = beq.search_by_title(
+                catalogue, title, year=year, codec=codec
+            )
+
+        if not results:
+            search_desc = f"TMDB ID {tmdb_id}" if tmdb_id else f"'{title}'"
+            if year:
+                search_desc += f" ({year})"
+            if codec:
+                search_desc += f" [{codec}]"
+            raise HomeAssistantError(
+                f"No BEQ filter found for {search_desc}"
+            )
+
+        entry = beq.best_match(results)
+        filters = beq.prepare_filters(entry)
+        entry_title = entry.get("title", "Unknown")
+        beq_label = entry.get("underlying", entry_title)
+
+        if not filters:
+            raise HomeAssistantError(
+                f"BEQ entry '{entry_title}' has no filters"
+            )
+
+        LOGGER.info(
+            "Loading BEQ filter: %s (%d filters, %d matches found)",
+            beq_label,
+            len(filters),
+            len(results),
+        )
+
+        success = await self._htp1.load_beq(beq_label, filters)
+        if not success:
+            raise HomeAssistantError("Failed to load BEQ filter on device")
+
+    async def async_clear_beq_filter(self) -> None:
+        """Clear the currently loaded BEQ filter."""
+        if not self.available:
+            raise HomeAssistantError("HTP-1 is not connected")
+
+        success = await self._htp1.clear_beq()
+        if not success:
+            raise HomeAssistantError("Failed to clear BEQ filter on device")

--- a/monoprice_htp1/sensor.py
+++ b/monoprice_htp1/sensor.py
@@ -551,6 +551,13 @@ SENSOR_DEFINITIONS = [
         "value_fn": lambda htp1: STATE_ON if htp1.peq_status else STATE_OFF,
         "icon": "mdi:music-note",
     },
+    {
+        "key": "beq_active",
+        "name": "BEQ Filter",
+        "path": "/peq/beqActive",
+        "value_fn": lambda htp1: htp1.beq_active or "None",
+        "icon": "mdi:equalizer",
+    },
 ]
 
 

--- a/monoprice_htp1/services.yaml
+++ b/monoprice_htp1/services.yaml
@@ -1,0 +1,35 @@
+load_beq_filter:
+  target:
+    entity:
+      integration: monoprice_htp1
+      domain: media_player
+  fields:
+    title:
+      example: "The Matrix"
+      required: false
+      selector:
+        text:
+    tmdb_id:
+      example: "603"
+      required: false
+      selector:
+        text:
+    year:
+      example: "1999"
+      required: false
+      selector:
+        number:
+          min: 1900
+          max: 2100
+          mode: box
+    codec:
+      example: "Atmos"
+      required: false
+      selector:
+        text:
+
+clear_beq_filter:
+  target:
+    entity:
+      integration: monoprice_htp1
+      domain: media_player

--- a/monoprice_htp1/strings.json
+++ b/monoprice_htp1/strings.json
@@ -14,5 +14,33 @@
     "abort": {
       "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
     }
+  },
+  "services": {
+    "load_beq_filter": {
+      "name": "Load BEQ filter",
+      "description": "Search the BEQ catalogue and load a bass correction filter onto the HTP-1. Provide either a movie title or TMDB ID.",
+      "fields": {
+        "title": {
+          "name": "Movie title",
+          "description": "Movie title to search for in the BEQ catalogue (case-insensitive substring match)."
+        },
+        "tmdb_id": {
+          "name": "TMDB ID",
+          "description": "The Movie Database (TMDB) ID for the movie or TV show."
+        },
+        "year": {
+          "name": "Year",
+          "description": "Release year to narrow down search results when multiple matches exist."
+        },
+        "codec": {
+          "name": "Audio codec",
+          "description": "Preferred audio codec to filter results (e.g. Atmos, DTS:X, TrueHD)."
+        }
+      }
+    },
+    "clear_beq_filter": {
+      "name": "Clear BEQ filter",
+      "description": "Remove the currently loaded BEQ bass correction filter from the HTP-1."
+    }
   }
 }

--- a/monoprice_htp1/translations/en.json
+++ b/monoprice_htp1/translations/en.json
@@ -19,5 +19,33 @@
         }
       }
     }
+  },
+  "services": {
+    "load_beq_filter": {
+      "name": "Load BEQ filter",
+      "description": "Search the BEQ catalogue and load a bass correction filter onto the HTP-1. Provide either a movie title or TMDB ID.",
+      "fields": {
+        "title": {
+          "name": "Movie title",
+          "description": "Movie title to search for in the BEQ catalogue (case-insensitive substring match)."
+        },
+        "tmdb_id": {
+          "name": "TMDB ID",
+          "description": "The Movie Database (TMDB) ID for the movie or TV show."
+        },
+        "year": {
+          "name": "Year",
+          "description": "Release year to narrow down search results when multiple matches exist."
+        },
+        "codec": {
+          "name": "Audio codec",
+          "description": "Preferred audio codec to filter results (e.g. Atmos, DTS:X, TrueHD)."
+        }
+      }
+    },
+    "clear_beq_filter": {
+      "name": "Clear BEQ filter",
+      "description": "Remove the currently loaded BEQ bass correction filter from the HTP-1."
+    }
   }
 }


### PR DESCRIPTION
## Summary
Adds support for loading [BEQ (Bass EQ)](https://beqcatalogue.readthedocs.io/) correction filters directly from Home Assistant. BEQ filters apply bass correction profiles to the HTP-1's PEQ slots for specific movies and TV shows, compensating for rolled-off low-frequency content in many modern soundtracks.
Implementation matches the HTP-1 web UI (`BassEq.vue`) behavior — same slot range, value formatting, and `changemso` payload structure. Verified working on a real HTP-1 with Dirac ART and 3 subwoofers.
Inspired by the BEQ catalogue support added in [v2.0.0 of the Unfolded Circle integration](https://github.com/mase1981/uc-intg-monoprice-htp1/releases/tag/2.0.0) by [@mase1981](https://github.com/mase1981). Thanks for the original idea and implementation reference — the catalogue search approach and PEQ slot management logic were adapted from that work.
## New features
- **`monoprice_htp1.load_beq_filter` service** — Search the BEQ catalogue and load a filter by:
  - Movie title (case-insensitive substring match)
  - TMDB ID (supports numeric IDs, string IDs, and full themoviedb.org URLs)
  - Optional year and audio codec filters to narrow results when multiple matches exist
- **`monoprice_htp1.clear_beq_filter` service** — Remove the currently loaded BEQ filter
- **BEQ Filter sensor** — Shows the name of the currently active BEQ filter (or "None")
## Usage examples
### Basic service calls
```yaml
# Load by movie title
service: monoprice_htp1.load_beq_filter
target:
  entity_id: media_player.htp_1
data:
  title: "The Matrix"
  codec: "Atmos"
# Load by TMDB ID
service: monoprice_htp1.load_beq_filter
target:
  entity_id: media_player.htp_1
data:
  tmdb_id: "603"
# Clear current filter
service: monoprice_htp1.clear_beq_filter
target:
  entity_id: media_player.htp_1
```
### Auto-load BEQ on movie playback
Media player integrations like **Zidoo** and **Kodi** expose the TMDB ID of the currently playing movie in their entity attributes. You can use this to automatically load the correct BEQ filter whenever a movie starts playing:
```yaml
automation:
  - alias: "Auto-load BEQ filter on movie playback"
    trigger:
      - platform: state
        entity_id: media_player.zidoo
        to: "playing"
    condition:
      - condition: template
        value_template: >
          {{ state_attr('media_player.zidoo', 'media_tmdb_id') not in [None, ''] }}
    action:
      - service: monoprice_htp1.load_beq_filter
        target:
          entity_id: media_player.htp_1
        data:
          tmdb_id: "{{ state_attr('media_player.zidoo', 'media_tmdb_id') }}"
          codec: "Atmos"
  - alias: "Clear BEQ filter when playback stops"
    trigger:
      - platform: state
        entity_id: media_player.zidoo
        from: "playing"
    action:
      - service: monoprice_htp1.clear_beq_filter
        target:
          entity_id: media_player.htp_1
```
A similar automation works with Kodi, where the TMDB ID can be sourced from attributes exposed by the Kodi integration or a custom sensor via Kodi's JSON-RPC API.
## Technical details
- Filters written to PEQ slots on all active sub channels, finding empty slots by `gaindB === 0` (matching web UI logic)
- Uses the `underlying` catalogue field for `beqActive` so the web UI can resolve the display name
- Clear scans all 16 PEQ slots across sub1-sub5 (matching web UI `clearAllExistingBeqFilters`)
- Enables PEQ (`peqsw = true`) after loading (matching web UI `setGlobalPEQOn`)
- Sends integer values for whole numbers (e.g. `10` not `10.0`) matching web UI `convertFloat`/`JSON.stringify` behavior
- All clear + load ops sent in a single `changemso` batch
- `msoupdate` handler now supports `remove` operations (required for clearing BEQ state)
- BEQ catalogue fetched from `beqcatalogue.readthedocs.io` and cached in memory for 1 hour using HA's shared aiohttp session
- Services registered as entity services on the media player platform with full HA developer tools UI support
